### PR TITLE
Fix README.md in manifest file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,5 @@ include AUTHORS.rst
 include CONTRIBUTING.rst
 include HISTORY.rst
 include LICENSE
-include README.rst
+include README.md
 recursive-include prettyjson *.html *.png *.gif *js *.css *jpg *jpeg *svg *py


### PR DESCRIPTION
The wrong filename for the readme can break older versions of pip (it failed with 6.1.1, but it worked fine with newer versions) since the actual `README.md` won't be included.
