### PR TITLE
Django 5.1: use `mark_safe` for `PrettyJSONWidget`

### DIFF
--- a/prettyjson/widgets.py
+++ b/prettyjson/widgets.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.forms import widgets
-
+from django.utils.safestring import mark_safe
 
 class PrettyJSONWidget(widgets.Textarea):
 
@@ -14,7 +14,7 @@ class PrettyJSONWidget(widgets.Textarea):
         if (start_as not in self._allowed_attrs()):
             start_as = self.DEFAULT_ATTR
 
-        return ('<div class="jsonwidget" data-initial="' + start_as + '"><p><button class="parseraw" '
+        return mark_safe('<div class="jsonwidget" data-initial="' + start_as + '"><p><button class="parseraw" '
                 'type="button">Show parsed</button> <button class="parsed" '
                 'type="button">Collapse all</button> <button class="parsed" '
                 'type="button">Expand all</button></p>' + html + '<div '

--- a/prettyjson/widgets.py
+++ b/prettyjson/widgets.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.forms import widgets
 from django.utils.safestring import mark_safe
 
+
 class PrettyJSONWidget(widgets.Textarea):
 
     DEFAULT_ATTR = 'raw'
@@ -14,11 +15,13 @@ class PrettyJSONWidget(widgets.Textarea):
         if (start_as not in self._allowed_attrs()):
             start_as = self.DEFAULT_ATTR
 
-        return mark_safe('<div class="jsonwidget" data-initial="' + start_as + '"><p><button class="parseraw" '
-                'type="button">Show parsed</button> <button class="parsed" '
-                'type="button">Collapse all</button> <button class="parsed" '
-                'type="button">Expand all</button></p>' + html + '<div '
-                'class="parsed"></div></div>')
+        return mark_safe(
+            '<div class="jsonwidget" data-initial="' + start_as + '"><p><button class="parseraw" '
+            'type="button">Show parsed</button> <button class="parsed" '
+            'type="button">Collapse all</button> <button class="parsed" '
+            'type="button">Expand all</button></p>' + html + '<div '
+            'class="parsed"></div></div>'
+            )
 
     @staticmethod
     def _allowed_attrs():


### PR DESCRIPTION
After upgrading to Django 5.1 we notice that the `PrettyJSONWidget` was broken in the admin. It seems to be because the HTML code returned is not marked as safe.

I tested the behavior locally and also run the tests coming along the projects to be sure I was not breaking anything.


### Before 
![Screenshot 2024-06-03 at 16 01 56](https://github.com/kevinmickey/django-prettyjson/assets/616052/c3ea8413-7b0f-43ee-9023-75ff04da5544)

### After
![Screenshot 2024-06-03 at 16 01 23](https://github.com/kevinmickey/django-prettyjson/assets/616052/9f16fca0-98a7-43da-8016-e2e18083e1db)
